### PR TITLE
Update CircleShapeLayer.m

### DIFF
--- a/CircularProgressControl/CircularProgressView/CircleShapeLayer.m
+++ b/CircularProgressControl/CircularProgressView/CircleShapeLayer.m
@@ -106,9 +106,12 @@
 
 - (void)startAnimation {
     
+    CALayer *presentation = (CALayer*)[self.progressLayer presentationLayer];
+    NSValue *prevVal = [presentation valueForKey:@"strokeEnd"];
+    
     CABasicAnimation *pathAnimation = [CABasicAnimation animationWithKeyPath:@"strokeEnd"];
     pathAnimation.duration = 1.0;
-    pathAnimation.fromValue = @(self.initialProgress);
+    pathAnimation.fromValue = prevVal;
     pathAnimation.toValue = @(self.percent);
     pathAnimation.removedOnCompletion = YES;
     


### PR DESCRIPTION
Fixes a small lag when two animations are called too quickly. Now it starts the second animation from the current state instead of starting it from the toValue of the previous animation.
